### PR TITLE
Week 2

### DIFF
--- a/opensearch/bbuy_products.json
+++ b/opensearch/bbuy_products.json
@@ -1,5 +1,408 @@
 {
   "settings": {
-    "index.refresh_interval": "5s"
+    "analysis": {
+      "analyzer": {
+        "smarter_hyphens": {
+          "tokenizer": "smarter_hyphens_tokenizer",
+          "filter": [
+            "smarter_hyphens_filter",
+            "lowercase"
+          ]
+        }
+      },
+      "tokenizer": {
+        "smarter_hyphens_tokenizer": {
+          "type": "char_group",
+          "tokenize_on_chars": [
+            "whitespace",
+            "\n"
+          ]
+        }
+      },
+      "filter": {
+        "smarter_hyphens_filter": {
+          "type": "word_delimiter_graph",
+          "catenate_words": true,
+          "catenate_all": true
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "@version": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "accessories": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
+          },
+          "long": {
+            "type": "long",
+            "ignore_malformed": true
+          }
+        }
+      },
+      "active": {
+        "type": "boolean"
+      },
+      "bestBuyItemId": {
+        "type": "keyword"
+      },
+      "bestSellingRank": {
+        "type": "long"
+      },
+      "categoryPath": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
+          }
+        }
+      },
+      "categoryPathIds": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
+          }
+        }
+      },
+      "categoryLeaf": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 512
+          }
+        }
+      },
+      "class": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 512
+          }
+        }
+      },
+      "classId": {
+        "type": "integer"
+      },
+      "color": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "condition": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "customerReviewAverage": {
+        "type": "float"
+      },
+      "customerReviewCount": {
+        "type": "integer"
+      },
+      "department": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 512
+          }
+        }
+      },
+      "departmentId": {
+        "type": "integer"
+      },
+      "depth": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "description": {
+        "type": "text",
+        "analyzer": "english"
+      },
+      "digital": {
+        "type": "boolean"
+      },
+      "features": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 512
+          }
+        }
+      },
+      "frequentlyPurchasedWith": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "long": {
+            "type": "long"
+          }
+        }
+      },
+      "height": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "homeDelivery": {
+        "type": "boolean"
+      },
+      "host": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "image": {
+        "type": "keyword"
+      },
+      "inStoreAvailability": {
+        "type": "boolean"
+      },
+      "inStorePickup": {
+        "type": "boolean"
+      },
+      "longDescription": {
+        "type": "text",
+        "analyzer": "english"
+      },
+      "longDescriptionHtml": {
+        "type": "keyword"
+      },
+      "manufacturer": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 1024
+          }
+        }
+      },
+      "message": {
+        "type": "text"
+      },
+      "modelNumber": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
+          },
+          "hyphens": {
+            "type": "text",
+            "analyzer": "smarter_hyphens"
+          },
+          "suggest": {
+            "type": "completion"
+          }
+
+        }
+      },
+      "onSale": {
+        "type": "boolean"
+      },
+      "onlineAvailability": {
+        "type": "boolean"
+      },
+      "path": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "productId": {
+        "type": "long"
+      },
+      "product_id": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "quantityLimit": {
+        "type": "integer"
+      },
+      "regularPrice": {
+        "type": "float"
+      },
+      "relatedProducts": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "long": {
+            "type": "long"
+          }
+        }
+      },
+      "releaseDate": {
+        "type": "date"
+      },
+      "salePrice": {
+        "type": "float"
+      },
+      "salesRankLongTerm": {
+        "type": "long"
+      },
+      "salesRankMediumTerm": {
+        "type": "long"
+      },
+      "salesRankShortTerm": {
+        "type": "long"
+      },
+      "shipping": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "shippingCost": {
+        "type": "float"
+      },
+      "shippingWeight": {
+        "type": "float"
+      },
+      "shortDescription": {
+        "type": "text",
+        "analyzer": "english"
+      },
+      "shortDescriptionHtml": {
+        "type": "keyword"
+      },
+      "sku": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "startDate": {
+        "type": "date"
+      },
+      "subclass": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "subclassId": {
+        "type": "long"
+      },
+      "tags": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "type": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "url": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 2048
+          }
+        }
+      },
+      "weight": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "width": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      }
+    }
   }
 }

--- a/opensearch/bbuy_queries.json
+++ b/opensearch/bbuy_queries.json
@@ -1,5 +1,69 @@
 {
   "settings": {
     "index.refresh_interval": "5s"
+  },
+  "mappings": {
+    "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
+      "@version": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "category": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "click_time": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss.S||yyyy-MM-dd HH:mm:ss.SS||yyyy-MM-dd HH:mm:ss.SSSZ||yyyy-MM-dd HH:mm:ss.SSS||yyyy-MM-dd HH:mm:ssZ||yyyy-MM-dd||epoch_millis||strict_date_optional_time"
+      },
+      "query": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          },
+          "stemmed": {
+            "type": "text",
+            "analyzer": "english"
+          }
+        }
+      },
+      "query_time": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss.S||yyyy-MM-dd HH:mm:ss.SS||yyyy-MM-dd HH:mm:ss.SSSZ||yyyy-MM-dd HH:mm:ss.SSS||yyyy-MM-dd HH:mm:ssZ||yyyy-MM-dd||epoch_millis||strict_date_optional_time"
+      },
+      "sku": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "user": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      }
+    }
   }
 }

--- a/week2/utilities/build_ltr.py
+++ b/week2/utilities/build_ltr.py
@@ -295,6 +295,7 @@ if __name__ == "__main__":
                 the_feature_set = json.load(json_file)
                 # Log our features for the training set
                 print("Logging features")
+                
                 features_df = data_prepper.log_features(impressions_df, terms_field=args.ltr_terms_field)
                 # Calculate some stats so we can normalize values.
                 # Since LTR only supports min/max, mean/std. dev and sigmoid, we can only do that

--- a/week2/utilities/click_models.py
+++ b/week2/utilities/click_models.py
@@ -8,8 +8,15 @@ def binary_func(x):
     return 0
 
 def step(x):
-    print("IMPLEMENT ME: step(x) a step function with a simple heuristic that buckets grades")
-    return rng.choice([0,0.5, 1.0])
+    if x < 0.02:
+        return 0
+    elif 0.02 <= x < 0.05:
+        return 0.25
+    elif 0.05 <= x < 0.10:
+        return 0.50
+    elif 0.10 <= x < 0.30:
+        return 0.75
+    return 1
 
 
 rng = np.random.default_rng(123456)
@@ -28,7 +35,9 @@ def apply_click_model(data_frame, click_model_type="binary", downsample=True):
             data_frame = down_sample_continuous(data_frame)
     elif click_model_type == "heuristic":
         data_frame["grade"] = (data_frame["clicks"]/data_frame["num_impressions"]).fillna(0).apply(lambda x: step(x))
-        print("IMPLEMENT ME: apply_click_model(): downsampling")
+        if downsample:
+            data_frame = down_sample_buckets(data_frame)
+        print("Debuggin:  apply_click_model(): downsampling")
     return data_frame
 
 # https://stackoverflow.com/questions/55119651/downsampling-for-more-than-2-classes

--- a/week2/utilities/ltr_utils.py
+++ b/week2/utilities/ltr_utils.py
@@ -17,8 +17,7 @@ def create_rescore_ltr_query(user_query, query_obj, click_prior_query, ltr_model
                             "click_prior_query": click_prior_query,
                         },
                         "model": ltr_model_name,
-                        "store": ltr_store_name,
-                        "active_features": active_features
+                        "store": ltr_store_name
                     }
                 },
                 "query_weight": main_query_weight,

--- a/week2/utilities/ltr_utils.py
+++ b/week2/utilities/ltr_utils.py
@@ -6,9 +6,28 @@ import requests
 def create_rescore_ltr_query(user_query, query_obj, click_prior_query, ltr_model_name, ltr_store_name,
                              active_features=None, rescore_size=500, main_query_weight=1, rescore_query_weight=2):
     # Create the base query, use a much bigger window
-    #add on the rescore
-    print("IMPLEMENT ME: create_rescore_ltr_query")
+    # add on the rescore
+    query_obj["rescore"] = {
+            "window_size": rescore_size,
+            "query": {
+                "rescore_query": {
+                   "sltr": {
+                        "params": {
+                            "keywords": user_query,
+                            "click_prior_query": click_prior_query,
+                        },
+                        "model": ltr_model_name,
+                        "store": ltr_store_name,
+                        "active_features": active_features
+                    }
+                },
+                "query_weight": main_query_weight,
+                "rescore_query_weight": rescore_query_weight
+            }
+        }
+
     return query_obj
+
 
 # take an existing query and add in an SLTR so we can use it for explains to see how much SLTR contributes
 def create_sltr_simple_query(user_query, query_obj, click_prior_query, ltr_model_name, ltr_store_name, active_features=None):
@@ -51,7 +70,27 @@ def create_sltr_hand_tuned_query(user_query, query_obj, click_prior_query, ltr_m
 
 def create_feature_log_query(query, doc_ids, click_prior_query, featureset_name, ltr_store_name, size=200, terms_field="_id"):
     print("IMPLEMENT ME: create_feature_log_query")
-    return None
+
+    sltr = {
+        "sltr": {
+            "_name": ltr_store_name,
+            "featureset": featureset_name,
+            "params": {
+                "keywords": query
+            },
+
+            "ext": {
+                "ltr_log": {
+                    "log_specs": {
+                        "name": "log_entry",
+                        "named_query": ltr_store_name
+                    }
+                }
+            }
+        }
+    }
+
+    return sltr
 
 
 # Item is a Pandas namedtuple

--- a/week2/utilities/ltr_utils.py
+++ b/week2/utilities/ltr_utils.py
@@ -68,28 +68,45 @@ def create_sltr_hand_tuned_query(user_query, query_obj, click_prior_query, ltr_m
     return query_obj, len(query_obj["query"]["function_score"]["query"]["bool"]["should"])
 
 def create_feature_log_query(query, doc_ids, click_prior_query, featureset_name, ltr_store_name, size=200, terms_field="_id"):
-    print("IMPLEMENT ME: create_feature_log_query")
-
-    sltr = {
-        "sltr": {
-            "_name": ltr_store_name,
-            "featureset": featureset_name,
-            "params": {
-                "keywords": query
-            },
-
-            "ext": {
-                "ltr_log": {
-                    "log_specs": {
-                        "name": "log_entry",
-                        "named_query": ltr_store_name
+    print("Debugging: create_feature_log_query")
+    features_logging_query = {
+        "size": size,
+        "_source": [ "name", "sku" ],
+        "query": {
+            "bool": {
+                "filter": [
+                    {
+                        # Doc ids to retrieve LTR features for
+                        "terms": {
+                            terms_field: doc_ids
+                        }
+                    },
+                    {
+                    "sltr": {
+                        "_name": "logged_featureset",
+                        "featureset": featureset_name,
+                        "store": ltr_store_name,
+                        "params": {
+                            # The params for the query-dependent features
+                            "keywords": query,
+                            "click_prior_query": click_prior_query
+                        }
                     }
+                    }
+                ]
+                }
+        },
+        # Return the LTR features
+        "ext": {
+            "ltr_log": {
+                "log_specs": {
+                    "name": "log_entry",
+                    "named_query": "logged_featureset"
                 }
             }
         }
     }
-
-    return sltr
+    return features_logging_query
 
 
 # Item is a Pandas namedtuple

--- a/week2/utilities/xgb_utils.py
+++ b/week2/utilities/xgb_utils.py
@@ -32,5 +32,6 @@ def train(xgb_train_data, num_rounds=5, xgb_conf=None ):
         with open(xgb_conf) as json_file:
             xgb_params = json.load(json_file)
     print("Training XG Boost on %s for %s rounds with params: %s" % (xgb_train_data, num_rounds, xgb_params))
-    print("IMPLEMENT ME: train()")
+    dtrain = xgb.DMatrix(xgb_train_data)
+    bst = xgb.train(xgb_params, dtrain, num_rounds)
     return bst, xgb_params


### PR DESCRIPTION
# Week 2 Project Assessment

- Do you understand the steps involved in creating and deploying an LTR model? Name them and describe what each step does in your own words.
   - In theory I do, but I had a lot going on during this part of the course and had to do this project in discrete chunks. So, I don't know how much I fully understand the end-to-end process
   - Step 1: get your training data together (index-time signals, query-time signals)
       - You have to put these features into a JSON file & add a [rescore query](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/filter-search-results.html#rescore) to your OS query
       - Make sure your training data is relatively well balanced
       - Inspect for nulls, outliers, etc.
   - Step 2: train your model 
       - Make sure you don't have too much data leakage between your training, test, & eval features 
   - Step 3: evaluate your model on a holdout set 
       - Make sure you log everything w/an [sltr query](https://elasticsearch-learning-to-rank.readthedocs.io/en/latest/logging-features.html) for good ML hygiene 
   - Step 4: tweak parameters, feature engineer, etc.
   - Step 5: yay, go to prod!

---

- What is a feature and featureset?
    - A feature is a vector of data that represents a detail about your underlying data (e.g. aggregations of metadata, names of people, etc.)
    - A featureset is just a bunch of those :) 

---
 
- What is the difference between precision and recall?
   - Precision is the # of relevant documents you retrieve at cutoff `k` out of all documents retrieved
   - Recall is the # of relevant documents you retrieve at cutoff `k` out of all _relevant_ documents retrieved

---

- What are some of the traps associated with using click data in your model?
    - You can inadvertently bias your model towards head queries, therefore creating an endless loop of head queries showing up higher in the SERP than tail queries and those head queries will be the only ones users end up seeing, creating a closed universe for the user
    - If you don't take magnitude of clicks into account, you can bias your model towards extremely popular queries, similar to above ^
    - Clicks are often noisy, since they are prone to position bias, presentation bias, mistakes, etc.

---

- What are some of the ways we are faking our data and how would you prevent that in your application?
    - We are faking impressions, since we have no real impressions, since we're using a historic dataset with only clicks in it
    - We are adding "click priors" to our training data in an attempt to normalize queries by their popularity
    - In my application, I would probably do the same, but I'd use a slightly more sophisticated click model (e.g. a dynamic bayesian network model)

---

- What is target leakage and why is it a bad thing?
    - Target leakage is when your training data has anomalies in it -- these can be anything from duplicate data to features that are unavailable at prediction time.
    - In that latter scenario, your model has no chance of doing well if you train it on features that are not available at prediction time, since you'll be asking your model to predict something based on never-before-seen types of data.
    - In the former scenario, your model will be overfit and over simplified -- this makes it less robust to outliers at prediction time & a false impression that your model will do well (when you evaluate it before shipping it to prod)

---

- When can using prior history cause problems in search and LTR?
    - When your prior history no longer represents the system you're trying to optimize. If your training data is not reflective of your current system (let's say someone pushed a change to your ranking algorithm), your LTR model will not perform well.

---

- Best LTR scores were achieved when I added the click prior query & made the rescore function have an enormous weight (`1000`) compared to the baseline model: 
<img width="429" alt="ltr_rescore_1000" src="https://user-images.githubusercontent.com/18585860/156863125-fd0835bb-861f-4a8c-a860-c9e142623cc8.png">

