### PR TITLE
[SUBMISSION] Week 4

### DIFF
--- a/week4/search.py
+++ b/week4/search.py
@@ -170,14 +170,14 @@ def query():
     query_class_model = current_app.config["query_model"]
     query_category = get_query_category(user_query, query_class_model)
     print("query obj: {}".format(query_obj))
-    if len(query_category) > 0 and user_query != '*':
-        query_obj['query']['bool']['filter'].append(
+    if len(query_category) > 0 and user_query != '*' and 'query' in query_obj and 'bool' in query_obj['query']:
+        query_obj['query']['bool']['filter'] = [
             {
                 'terms': {
                     'categoryPathIds.keyword': query_category
                 }
             }
-        )
+        ]
     response = opensearch.search(body=query_obj, index=current_app.config["index_name"], explain=explain)
     # Postprocess results here if you so desire
 

--- a/week4/search.py
+++ b/week4/search.py
@@ -10,6 +10,14 @@ from week4.opensearch import get_opensearch
 import week4.utilities.query_utils as qu
 import week4.utilities.ltr_utils as lu
 
+import nltk
+nltk.download('stopwords')
+stemmer = nltk.stem.PorterStemmer()
+stop_words = set(nltk.corpus.stopwords.words('english'))
+
+NUM_TO_PREDICT = 10
+SCORE_THRESHOLD = 0.5
+
 bp = Blueprint('search', __name__, url_prefix='/search')
 
 
@@ -56,9 +64,32 @@ def process_filters(filters_input):
 
     return filters, display_filters, applied_filters
 
+def normalize_query(query):
+    print(f'Normalizing query {query}')
+    query = query.lower()
+    query = re.sub('[\'"]', '', query)
+    tokenized_query = nltk.word_tokenize(query)
+    tokenized_query = [t for t in tokenized_query if t not in stop_words]
+    tokenized_query = [stemmer.stem(t) for t in tokenized_query]
+    query = ' '.join(tokenized_query)
+    print(f'Done normalizing, got {query}')
+    return query
+
 def get_query_category(user_query, query_class_model):
-    print("IMPLEMENT ME: get_query_category")
-    return None
+    norm_query = normalize_query(user_query)
+    print('Predicting...')
+    categories, scores = query_class_model.predict(stemmer_query, NUM_TO_PREDICT)
+    categories_and_scores = [(c.replace('__label__', ''), s) for c, s in zip(categories, scores)]
+    print(f'Done predicting, got {categories_and_scores}')
+    accumulated_score = 0
+    res = []
+    for c, s in categories_and_scores:
+        res.append(c)
+        accumulated_score += s
+        if accumulated_score >= SCORE_THRESHOLD:
+            break
+    print(f'Query categorization result: {res}')
+    return res
 
 
 @bp.route('/query', methods=['GET', 'POST'])
@@ -138,8 +169,14 @@ def query():
     query_class_model = current_app.config["query_model"]
     query_category = get_query_category(user_query, query_class_model)
     if query_category is not None:
-        print("IMPLEMENT ME: add this into the filters object so that it gets applied at search time.  This should look like your `term` filter from week 1 for department but for categories instead")
-    #print("query obj: {}".format(query_obj))
+        query_obj['query']['bool']['filter'] = [
+            {
+                'terms': {
+                    'categoryPathIds.keyword': query_category
+                }
+            }
+        ]
+    print("query obj: {}".format(query_obj))
     response = opensearch.search(body=query_obj, index=current_app.config["index_name"], explain=explain)
     # Postprocess results here if you so desire
 


### PR DESCRIPTION
Q: How many unique categories did you see in your rolled up training data when you set the minimum number of queries per category to 100? To 1000?

A: Setting the minimum to 100 caused the num of categories to drop to 629. Setting it to 1000 caused it to drop to 122.

Q: What values did you achieve for P@1, R@3, and R@5? You should have tried at least a few different models, varying the minimum number of queries per category as well as trying different fastText parameters or query normalization. Report at least 3 of your runs.

A: I started with two models using the baseline fasttext parameters, for the datasets with 100 and 1000 min_queries. These scored, respectively, P@1 0.47 R@3 0.62 R@5 0.684 and P@1 0.546 R@3 0.73 R@5 0.791. I decided (somewhat arbitrarily) that the performance increase of moving to 1000 min_queries does not justify the loss of granularity. I proceeded to train a model on the 100 min_queries dataset using lr=0.1, epoch=25, wordNgrams=2. This achieved P@1 0.517 R@3 0.698 R@5 0.762, and I proceeded with this model to the next phase.


Note: the code for task 2 is implemented and included in this PR, but for some reason I'm still getting errors trying to test it on the Flask application. If I manage to sort this out within the time I have available, I will update this description with the answers to the remaining questions.