### PR TITLE
week 2 project

### DIFF
--- a/utilities/query.py
+++ b/utilities/query.py
@@ -75,6 +75,17 @@ def create_query(user_query, click_prior_query, filters, sort="_score", sortDir=
                                 }
                             },
                             {
+                                "match": {
+                                    "name.synonym": {
+                                        "query": user_query,
+                                        "fuzziness": "1",
+                                        "prefix_length": 2,
+                                        # short words are often acronyms or usually not misspelled, so don't edit
+                                        "boost": 0.01
+                                    }
+                                }
+                            },
+                            {
                                 "match_phrase": {  # near exact phrase match
                                     "name.hyphens": {
                                         "query": user_query,
@@ -89,7 +100,7 @@ def create_query(user_query, click_prior_query, filters, sort="_score", sortDir=
                                     "type": "phrase",
                                     "slop": "6",
                                     "minimum_should_match": "2<75%",
-                                    "fields": ["name^10", "name.hyphens^10", "shortDescription^5",
+                                    "fields": ["name^10", "name.hyphens^10", "name.synonym^10", "shortDescription^5",
                                                "longDescription^5", "department^0.5", "sku", "manufacturer", "features",
                                                "categoryPath", "name_synonyms"]
                                 }

--- a/week2/conf/bbuy_products.json
+++ b/week2/conf/bbuy_products.json
@@ -8,6 +8,10 @@
             "smarter_hyphens_filter",
             "lowercase"
           ]
+        },
+        "synonym": {
+          "tokenizer": "whitespace",
+          "filter": [ "lowercase", "synonym"]
         }
       },
       "tokenizer": {
@@ -24,6 +28,10 @@
           "type": "word_delimiter_graph",
           "catenate_words": true,
           "catenate_all": true
+        },
+        "synonym": {
+          "type": "synonym",
+          "synonyms_path": "synonyms.csv"
         }
       }
     }
@@ -248,8 +256,11 @@
           },
           "suggest": {
             "type": "completion"
-          }
-
+          },
+          "synonym": {
+            "type": "text",
+            "analyzer": "synonym"
+          } 
         }
       },
       "onSale": {

--- a/week2/get_synonyms.py
+++ b/week2/get_synonyms.py
@@ -1,0 +1,23 @@
+import argparse
+import pandas as pd
+from collections import Counter
+import matplotlib.pyplot as plt
+import fasttext
+
+model = fasttext.load_model("/workspace/datasets/fasttext/normalized_title_model.bin")
+input_file = '/workspace/datasets/fasttext/top_words.txt'
+output_file = '/workspace/datasets/fasttext/synonyms.csv'
+threshold = 0.75
+with open(input_file) as f:
+    words = f.readlines()
+
+
+with open(output_file, "w") as f:
+    for w in words:
+        synonyms = []
+        w = w.strip()
+        for n in model.get_nearest_neighbors(w):
+            if n[0] >= threshold:
+                synonyms.append(n[1])
+        if synonyms:
+            f.write('{},{}\n'.format(w, ",".join(synonyms)))

--- a/week2/prune_label.py
+++ b/week2/prune_label.py
@@ -1,0 +1,36 @@
+import argparse
+import pandas as pd
+from collections import Counter
+import matplotlib.pyplot as plt
+
+
+parser = argparse.ArgumentParser(description='Process some integers.')
+
+args = parser.parse_args()
+general = parser.add_argument_group("general")
+general.add_argument("--input", default="/workspace/datasets/fasttext/labeled_products.txt", help="the file to read from")
+general.add_argument("--output", default="/workspace/datasets/fasttext/pruned_labeled_products.txt", help="the file to output to")
+
+args = parser.parse_args()
+input_file = args.input
+output_file = args.output
+
+if __name__ == '__main__':
+    products = []
+    with open(input_file) as f:
+        lines = f.readlines()
+    for line in lines:
+        products.append(line.split(" ", 1))
+    c = Counter(product[0] for product in products)
+    print(c)
+
+    pruned_products = []
+    for product in products:
+        if c[product[0]] >= 500:
+            pruned_products.append(product)
+    print('product cnt before prune {}, after prune {}'.format(len(products), len(pruned_products)))
+    with open(output_file, "w") as f:
+        for product in pruned_products:
+            f.write('{} {}'.format(product[0], product[1]))
+        
+    # df_pruned = df[df['label'].value_counts() > 50]


### PR DESCRIPTION
# For classifying product names to categories:

What precision (P@1) were you able to achieve?
```
	0.972
N       10000
P@1     0.972
R@1     0.972
```

What fastText parameters did you use?
`-epoch 25 -lr 1.0`

How did you transform the product names?
`Basic normalization with cat /workspace/datasets/fasttext/titles.txt | sed -e "s/\([.\!?,'/()]\)/ \1 /g" | tr "[:upper:]" "[:lower:]" | sed "s/[^[:alnum:]]/ /g" | tr -s ' ' > /workspace/datasets/fasttext/normalized_titles.txt`

How did you prune infrequent category labels, and how did that affect your precision?
`Only kept those >= 500`

How did you prune the category tree, and how did that affect your precision?
`n/a`


# For deriving synonyms from content:
What were the results for your best model in the tokens used for evaluation?
```Query word? headphones
earbud 0.905644
ear 0.845702
headphone 0.839297
bud 0.69057
earphones 0.676308
lowrider 0.660841
hesh 0.633925
over 0.624343
earbuds 0.623657
skullcandy 0.62178
Query word? laptop
notebook 0.692576
netbook 0.65727
briefcase 0.582429
mouse 0.55575
ultrabook 0.547577
laptops 0.53433
slip 0.530689
notebooks 0.524673
intel 0.524157
dell 0.508865
Query word? freezer
refrigerator 0.692304
satina 0.64328
cu 0.640248
ft 0.614311
mug 0.606155
side 0.604349
monochromatic 0.594813
cleansteel 0.590864
refrigerators 0.582476
bottom 0.58207
Query word? nintendo
ds 0.951344
wii 0.928374
3ds 0.811953
gamecube 0.781564
psp 0.745166
playstation 0.727058
360 0.719668
advance 0.711397
xbox 0.702221
boy 0.697776
Query word? whirlpool
maytag 0.776779
biscuit 0.770821
ge 0.730641
inglis 0.72874
frigidaire 0.721014
kitchenaid 0.646531
hotpoint 0.643468
cleansteel 0.642222
bisque 0.635692
profile 0.622819
Query word? kodak
easyshare 0.822217
m863 0.664368
m893 0.633638
m340 0.621361
m1063 0.612199
esp 0.607027
playsport 0.606702
canon 0.587238
coolpix 0.577677
playtouch 0.548279
Query word? ps2
gamecube 0.738747
playstation 0.734841
gba 0.718669
guide 0.709833
xbox 0.69513
ps3 0.695107
360 0.688647
psp 0.649729
cheats 0.633011
boy 0.611122
Query word? razr
motorola 0.782346
droid 0.729152
cell 0.657685
nokia 0.656847
phones 0.652858
palm 0.625493
kyocera 0.620256
atrix 0.619855
sph 0.615378
treo 0.597024
Query word? stratocaster
telecaster 0.869886
squier 0.783203
fender 0.76582
strat 0.761604
fretboard 0.754883
rosewood 0.625218
sunburst 0.60643
bullet 0.569439
olympic 0.551911
jazz 0.551175
Query word? holiday
congratulations 0.606775
hanukkah 0.605645
kwanzaa 0.60535
graduation 0.592707
thank 0.589142
happy 0.589032
gift 0.577151
cake 0.572081
navidad 0.570635
merry 0.555239
Query word? plasma
600hz 0.758345
hdtv 0.661678
dlp 0.627997
viera 0.626827
tv 0.597444
58 0.579835
63 0.57958
42 0.571673
240hz 0.56989
class 0.56852
Query word? leather
recliner 0.66323
armless 0.642863
berkline 0.632922
sofa 0.600379
curved 0.579534
seating 0.57626
magnolia 0.547099
theaterseatstore 0.54456
kenneth 0.537777
case 0.530822
```

What fastText parameters did you use?
 `-epoch 25 -minCount 20` 

How did you transform the product names?
`Basic normalization with cat /workspace/datasets/fasttext/titles.txt | sed -e "s/\([.\!?,'/()]\)/ \1 /g" | tr "[:upper:]" "[:lower:]" | sed "s/[^[:alnum:]]/ /g" | tr -s ' ' > /workspace/datasets/fasttext/normalized_titles.txt`


# For integrating synonyms with search:
How did you transform the product names (if different than previously)?
`same as above`
What threshold score did you use?
`0.75`
Were you able to find the additional results by matching synonyms?
`yes for earbuds and dslr, no for nespresso (doesn't seem to be in the synonym.csv file)`
