### PR TITLE
query: change fileinput for sys.stdin

### DIFF
--- a/utilities/query.py
+++ b/utilities/query.py
@@ -9,7 +9,7 @@ import os
 from getpass import getpass
 from urllib.parse import urljoin
 import pandas as pd
-import fileinput
+import sys
 import logging
 
 
@@ -241,7 +241,7 @@ if __name__ == "__main__":
     index_name = args.index
     query_prompt = "\nEnter your query (type 'Exit' to exit or hit ctrl-c):"
     print(query_prompt)
-    for line in fileinput.input():
+    for line in sys.stdin:
         query = line.rstrip()
         if query == "Exit":
             break


### PR DESCRIPTION
[Slack thread](https://corisers.slack.com/archives/C047AECU10R/p1667670802766449)

`fileinput.input()` will [parse files first](https://docs.python.org/3/library/fileinput.html) if any arguments are passed:

> This iterates over the lines of all files listed in sys.argv[1:], defaulting to sys.stdin if the list is empty. If a filename is '-', it is also replaced by sys.stdin and the optional arguments mode and openhook are ignored. To specify an alternative list of filenames, pass it as the first argument to [input()](dfile:///Users/simon/Library/Application%20Support/Dash/DocSets/Python_3/Python%203.docset/Contents/Resources/Documents/doc/library/fileinput.html#fileinput.input). A single file name is also allowed.

I am not sure if passing a file is essential in another course, but Chris Mantas suggested I PR this change.
