### PR TITLE
Show headings for count script

### DIFF
--- a/count-tracker.sh
+++ b/count-tracker.sh
@@ -2,8 +2,8 @@
 while [ true ];
 do
   echo "Queries:"
-  curl -k -XGET -u admin:admin  "https://localhost:9200/_cat/count/bbuy_queries";
+  curl -k -XGET -u admin:admin  "https://localhost:9200/_cat/count/bbuy_queries?v";
   echo "Products:"
-  curl -k -XGET -u admin:admin  "https://localhost:9200/_cat/count/bbuy_products";
+  curl -k -XGET -u admin:admin  "https://localhost:9200/_cat/count/bbuy_products?v";
   sleep 60;
 done


### PR DESCRIPTION
The first value in the _count/count output is a timestamp, but I confused it with a document count since it just looks like a big number. This adds the ?v option so it OpenSearch prints the headers.