### PR TITLE
query-utils-input-prompt-fix

### DIFF
--- a/utilities/query.py
+++ b/utilities/query.py
@@ -9,7 +9,6 @@ import os
 from getpass import getpass
 from urllib.parse import urljoin
 import pandas as pd
-import fileinput
 import logging
 
 
@@ -240,13 +239,9 @@ if __name__ == "__main__":
     )
     index_name = args.index
     query_prompt = "\nEnter your query (type 'Exit' to exit or hit ctrl-c):"
-    print(query_prompt)
-    for line in fileinput.input():
-        query = line.rstrip()
-        if query == "Exit":
+    while True:
+        query = input(query_prompt).rstrip()
+        if query.lower() == "exit":
             break
         search(client=opensearch, user_query=query, index=index_name)
-
-        print(query_prompt)
-
     


### PR DESCRIPTION
# Query utils input prompt fix

This PR aims to fix the issue that occurs when **utilities/query.py** is executed with arguments.

For example: `python utilities/query.py --host test`

Resulting:

```sh
Traceback (most recent call last):
  File "/utilities/query.py", line 244, in <module>
    for line in fileinput.input():
  File "/python3.9/fileinput.py", line 249, in __next__
    line = self._readline()
  File "/python3.9/fileinput.py", line 367, in _readline
    self._file = open(self._filename, self._mode)
FileNotFoundError: [Errno 2] No such file or directory: '--host'
```

## Changes

- replace `fileinput.input` with `input` in **utilities/query.py**